### PR TITLE
Add close() to authereum connector

### DIFF
--- a/packages/authereum-connector/src/index.ts
+++ b/packages/authereum-connector/src/index.ts
@@ -47,4 +47,9 @@ export class AuthereumConnector extends AbstractConnector {
   }
 
   public deactivate() {}
+
+  public async close() {
+    this.authereum.logout()
+    this.emitDeactivate()
+  }
 }


### PR DESCRIPTION
Adds `close()` to the Authereum connector to allow users to disconnect from Authereum.