### PR TITLE
Fix Torus connector's broken getAccount method

### DIFF
--- a/packages/torus-connector/src/index.ts
+++ b/packages/torus-connector/src/index.ts
@@ -43,7 +43,11 @@ export class TorusConnector extends AbstractConnector {
   }
 
   public async getAccount(): Promise<null | string> {
-    return this.torus.ethereum.send('eth_accounts').then((accounts: string[]): string => accounts[0])
+    return new Promise((res, rej) =>
+      this.torus.ethereum.send({ method: 'eth_accounts' }, (err: any, accounts: { result: string[] }): void =>
+        err ? rej(err) : res(accounts.result[0])
+      )
+    )
   }
 
   public async deactivate() {


### PR DESCRIPTION
Apparently the Web3 implementation used by the Torus client
doesn't support promises in the "send" method and requires a
callback.

---

Couple of issues here regarding "send":
- Promises are not supported, a callback is required
- Also it doesn't accept `eth_accounts` as input and doesn't return an array of accounts directly. Instead the input needs to be an object like `{method: 'eth_accounts'}` and the output is like `{result: accounts}`.

This may be caused by an out-of-date web3 version or something. I have no idea (don't know anything about the Torus client); all I know is that this fix works.

Hope this helps.