### PR TITLE
MetaMask Mobile compatibility fix

### DIFF
--- a/packages/core/src/normalizers.ts
+++ b/packages/core/src/normalizers.ts
@@ -4,6 +4,11 @@ import invariant from 'tiny-invariant'
 
 export function normalizeChainId(chainId: string | number): number {
   if (typeof chainId === 'string') {
+    // Temporary fix until the next version of Metamask Mobile gets released.
+    // In the current version (0.2.13), the chainId starts with “Ox” rather
+    // than “0x”. Fix: https://github.com/MetaMask/metamask-mobile/pull/1275
+    chainId = chainId.replace(/^Ox/, '0x')
+
     const parsedChainId = Number.parseInt(chainId, chainId.trim().substring(0, 2) === '0x' ? 16 : 10)
     invariant(!Number.isNaN(parsedChainId), `chainId ${chainId} is not an integer`)
     return parsedChainId


### PR DESCRIPTION
In the current version (0.2.13) of MetaMask Mobile, `ethereum.chainId` starts with “Ox” rather than “0x”.

The fix should be in the next version, but we might want to keep this for a bit until MetaMask Mobile users are up to date.

Reference: https://github.com/MetaMask/metamask-mobile/pull/1275
