### PR TITLE
Remove RPC map limit to one key for WalletConnect connector

### DIFF
--- a/packages/walletconnect-connector/package.json
+++ b/packages/walletconnect-connector/package.json
@@ -35,7 +35,7 @@
     "lint": "tsdx lint src"
   },
   "dependencies": {
-    "@walletconnect/web3-provider": "^1.0.0-beta.39",
+    "@walletconnect/web3-provider": "^1.0.0-rc.4",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
     "tiny-invariant": "^1.0.6"

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -28,7 +28,6 @@ export class WalletConnectConnector extends AbstractConnector {
   public walletConnectProvider: any
 
   constructor({ rpc, bridge, qrcode, pollingInterval }: WalletConnectConnectorArguments) {
-    invariant(Object.keys(rpc).length === 1, '@walletconnect/web3-provider is broken with >1 chainId, please use 1')
     super({ supportedChainIds: Object.keys(rpc).map(k => Number(k)) })
 
     this.rpc = rpc

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -20,7 +20,7 @@ interface WalletConnectConnectorArguments {
 }
 
 export class WalletConnectConnector extends AbstractConnector {
-  private readonly rpc: { [chainId: number]: string | undefined }
+  private readonly rpc: { [chainId: number]: string }
   private readonly bridge?: string
   private readonly qrcode?: boolean
   private readonly pollingInterval?: number


### PR DESCRIPTION
This shouldn't be necessary... it actually makes it impossible for someone to support multiple networks without Infura

Could you test this with @walletconnect/web3-provider@1.0.0-rc.4??

