### PR TITLE
Fix compatibility with ethers.js buildEip1193Fetcher

### DIFF
--- a/packages/network-connector/src/index.ts
+++ b/packages/network-connector/src/index.ts
@@ -49,8 +49,8 @@ class MiniRpcProvider implements AsyncSendable {
     params?: unknown[] | object
   ): Promise<unknown> => {
     if (typeof method !== 'string') {
-      method = method.method
       params = (method as any).params
+      method = method.method
     }
 
     const response = await fetch(this.url, {


### PR DESCRIPTION
Inside ethers.js web3-provider the request from buildEip1193Fetcher function looks like this:
`return provider.request({ method, params });`

In web3-react network-conenctor's `MiniRpcProvider` class, the `request` method overwrites `method` argument in a way that `params` will always end up undefined unless the `method` argument is a string and `params` is passed separately.

This pull request fixes this behaviour.