### PR TITLE
Dynamic imports: only use .default when present

### DIFF
--- a/packages/authereum-connector/src/index.ts
+++ b/packages/authereum-connector/src/index.ts
@@ -29,7 +29,7 @@ export class AuthereumConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.authereum) {
-      const { default: Authereum } = await import('authereum')
+      const Authereum = await import('authereum').then((m) => m?.default ?? m)
       this.authereum = new Authereum({
         networkName: chainIdToNetwork[this.chainId],
         ...this.config

--- a/packages/authereum-connector/src/index.ts
+++ b/packages/authereum-connector/src/index.ts
@@ -29,7 +29,7 @@ export class AuthereumConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.authereum) {
-      const Authereum = await import('authereum').then((m) => m?.default ?? m)
+      const Authereum = await import('authereum').then(m => m?.default ?? m)
       this.authereum = new Authereum({
         networkName: chainIdToNetwork[this.chainId],
         ...this.config

--- a/packages/fortmatic-connector/src/index.ts
+++ b/packages/fortmatic-connector/src/index.ts
@@ -30,7 +30,7 @@ export class FortmaticConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.fortmatic) {
-      const Fortmatic = await import('fortmatic').then((m) => m?.default ?? m)
+      const Fortmatic = await import('fortmatic').then(m => m?.default ?? m)
       this.fortmatic = new Fortmatic(
         this.apiKey,
         this.chainId === 1 || this.chainId === 4 ? undefined : chainIdToNetwork[this.chainId]

--- a/packages/fortmatic-connector/src/index.ts
+++ b/packages/fortmatic-connector/src/index.ts
@@ -30,7 +30,7 @@ export class FortmaticConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.fortmatic) {
-      const { default: Fortmatic } = await import('fortmatic')
+      const Fortmatic = await import('fortmatic').then((m) => m?.default ?? m)
       this.fortmatic = new Fortmatic(
         this.apiKey,
         this.chainId === 1 || this.chainId === 4 ? undefined : chainIdToNetwork[this.chainId]

--- a/packages/portis-connector/src/index.ts
+++ b/packages/portis-connector/src/index.ts
@@ -77,7 +77,7 @@ export class PortisConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.portis) {
-      const Portis = await import('@portis/web3').then((m) => m?.default ?? m)
+      const Portis = await import('@portis/web3').then(m => m?.default ?? m)
       this.portis = new Portis(
         this.dAppId,
         typeof this.networks[0] === 'number' ? chainIdToNetwork[this.networks[0]] : (this.networks[0] as any),

--- a/packages/portis-connector/src/index.ts
+++ b/packages/portis-connector/src/index.ts
@@ -77,7 +77,7 @@ export class PortisConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.portis) {
-      const { default: Portis } = await import('@portis/web3')
+      const Portis = await import('@portis/web3').then((m) => m?.default ?? m)
       this.portis = new Portis(
         this.dAppId,
         typeof this.networks[0] === 'number' ? chainIdToNetwork[this.networks[0]] : (this.networks[0] as any),

--- a/packages/squarelink-connector/src/index.ts
+++ b/packages/squarelink-connector/src/index.ts
@@ -41,7 +41,7 @@ export class SquarelinkConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.squarelink) {
-      const { default: Squarelink } = await import('squarelink')
+      const Squarelink = await import('squarelink').then((m) => m?.default ?? m)
       this.squarelink = new Squarelink(
         this.clientId,
         typeof this.networks[0] === 'number' ? chainIdToNetwork[this.networks[0]] : this.networks[0],

--- a/packages/squarelink-connector/src/index.ts
+++ b/packages/squarelink-connector/src/index.ts
@@ -41,7 +41,7 @@ export class SquarelinkConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.squarelink) {
-      const Squarelink = await import('squarelink').then((m) => m?.default ?? m)
+      const Squarelink = await import('squarelink').then(m => m?.default ?? m)
       this.squarelink = new Squarelink(
         this.clientId,
         typeof this.networks[0] === 'number' ? chainIdToNetwork[this.networks[0]] : this.networks[0],

--- a/packages/torus-connector/src/index.ts
+++ b/packages/torus-connector/src/index.ts
@@ -27,7 +27,7 @@ export class TorusConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.torus) {
-      const Torus = await import('@toruslabs/torus-embed').then((m) => m?.default ?? m)
+      const Torus = await import('@toruslabs/torus-embed').then(m => m?.default ?? m)
       this.torus = new Torus(this.constructorOptions)
       await this.torus.init(this.initOptions)
     }

--- a/packages/torus-connector/src/index.ts
+++ b/packages/torus-connector/src/index.ts
@@ -27,7 +27,7 @@ export class TorusConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.torus) {
-      const { default: Torus } = await import('@toruslabs/torus-embed')
+      const Torus = await import('@toruslabs/torus-embed').then((m) => m?.default ?? m)
       this.torus = new Torus(this.constructorOptions)
       await this.torus.init(this.initOptions)
     }

--- a/packages/trezor-connector/src/index.ts
+++ b/packages/trezor-connector/src/index.ts
@@ -48,7 +48,7 @@ export class TrezorConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.provider) {
-      const TrezorConnect = await import('trezor-connect').then((m) => m?.default ?? m)
+      const TrezorConnect = await import('trezor-connect').then(m => m?.default ?? m)
       TrezorConnect.manifest({
         email: this.manifestEmail,
         appUrl: this.manifestAppUrl

--- a/packages/trezor-connector/src/index.ts
+++ b/packages/trezor-connector/src/index.ts
@@ -48,7 +48,7 @@ export class TrezorConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.provider) {
-      const { default: TrezorConnect } = await import('trezor-connect')
+      const TrezorConnect = await import('trezor-connect').then((m) => m?.default ?? m)
       TrezorConnect.manifest({
         email: this.manifestEmail,
         appUrl: this.manifestAppUrl

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -73,7 +73,7 @@ export class WalletConnectConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.walletConnectProvider) {
-      const { default: WalletConnectProvider } = await import('@walletconnect/web3-provider')
+      const WalletConnectProvider = await import('@walletconnect/web3-provider').then((m) => m?.default ?? m)
       this.walletConnectProvider = new WalletConnectProvider({
         bridge: this.bridge,
         rpc: this.rpc,

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -73,7 +73,7 @@ export class WalletConnectConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.walletConnectProvider) {
-      const WalletConnectProvider = await import('@walletconnect/web3-provider').then((m) => m?.default ?? m)
+      const WalletConnectProvider = await import('@walletconnect/web3-provider').then(m => m?.default ?? m)
       this.walletConnectProvider = new WalletConnectProvider({
         bridge: this.bridge,
         rpc: this.rpc,

--- a/packages/walletlink-connector/src/index.ts
+++ b/packages/walletlink-connector/src/index.ts
@@ -30,7 +30,7 @@ export class WalletLinkConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.walletLink) {
-      const { default: WalletLink } = await import('walletlink')
+      const WalletLink = await import('walletlink').then((m) => m?.default ?? m)
       this.walletLink = new WalletLink({
         appName: this.appName,
         darkMode: this.darkMode,

--- a/packages/walletlink-connector/src/index.ts
+++ b/packages/walletlink-connector/src/index.ts
@@ -30,7 +30,7 @@ export class WalletLinkConnector extends AbstractConnector {
 
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.walletLink) {
-      const WalletLink = await import('walletlink').then((m) => m?.default ?? m)
+      const WalletLink = await import('walletlink').then(m => m?.default ?? m)
       this.walletLink = new WalletLink({
         appName: this.appName,
         darkMode: this.darkMode,


### PR DESCRIPTION
This solves an issue where in some cases, the imported module returns the default export directly, rather than being on the `.default` property.

In CJS, the `import()` calls get transformed into `Promise.resolve(require("dependency"))` calls. Bundlers seem to stick to
CJS in this case, and pick the `main` field of the dependency, which is usually CJS with a `.default` prop.

In ESM, the `import()` calls don’t get transformed. In this case, bundlers seem to behave in different ways, by following one of the `main`, `module` and `browser` fields. In these two last cases, the default export is available directly and not on the `.default` property.

By checking if `.default` is defined and using the imported value otherwise, we make these imports compatible with these different
scenarios.