### PR TITLE
Added Outpost to projects using web3-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Open a PR to add your project to the list!_
 - [NFT Scribe](https://github.com/conlan/nft-scribe)
 - [Compound Liquidator](https://github.com/conlan/compound-liquidator)
 - [wildcards.world](https://github.com/wildcards-world/ui)
+- [Outpost](https://github.com/OutpostProtocol/outpost-app)
 
 ## Related Efforts
 


### PR DESCRIPTION
We'd like to add our project to the list of projects using web3-react. You can read our manifesto [here](https://www.outpost-protocol.com/post/0CDUvbFIFhMgQ2Bc44CsVZRC0atSCs8X1wo16fHORiE)