### PR TITLE
Move from the Node events module to eventemitter3

### DIFF
--- a/packages/abstract-connector/package.json
+++ b/packages/abstract-connector/package.json
@@ -34,7 +34,8 @@
     "lint": "tsdx lint src"
   },
   "dependencies": {
-    "@web3-react/types": "^6.0.7"
+    "@web3-react/types": "^6.0.7",
+    "eventemitter3": "^4.0.7"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/packages/abstract-connector/src/index.ts
+++ b/packages/abstract-connector/src/index.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import EventEmitter from 'eventemitter3'
 import { AbstractConnectorArguments, ConnectorUpdate, ConnectorEvent } from '@web3-react/types'
 
 export abstract class AbstractConnector extends EventEmitter {


### PR DESCRIPTION
This removes the need for a bundler to polyfill the Node `events` module in order to use web3-react.

We could also use [the `events` module on npm](https://www.npmjs.com/package/events), but [`eventemitter3`](https://github.com/primus/eventemitter3) has a few advantages over it.