### PR TITLE
Added 1337 & 31337 to Supported Chain IDs of Portis Connector

### DIFF
--- a/packages/portis-connector/src/index.ts
+++ b/packages/portis-connector/src/index.ts
@@ -19,6 +19,7 @@ const chainIdToNetwork: { [network: number]: string } = {
   18: 'thundercoreTestnet',
   163: 'lightstreams',
   122: 'fuse',
+  31337: 'hardhat',
   15001: 'maticTestnet'
 }
 

--- a/packages/portis-connector/src/index.ts
+++ b/packages/portis-connector/src/index.ts
@@ -19,6 +19,7 @@ const chainIdToNetwork: { [network: number]: string } = {
   18: 'thundercoreTestnet',
   163: 'lightstreams',
   122: 'fuse',
+  1337: 'devChai',
   31337: 'hardhat',
   15001: 'maticTestnet'
 }

--- a/packages/portis-connector/src/index.ts
+++ b/packages/portis-connector/src/index.ts
@@ -19,7 +19,7 @@ const chainIdToNetwork: { [network: number]: string } = {
   18: 'thundercoreTestnet',
   163: 'lightstreams',
   122: 'fuse',
-  1337: 'devChai',
+  1337: 'devChain',
   31337: 'hardhat',
   15001: 'maticTestnet'
 }


### PR DESCRIPTION
Hardhat uses 31337 for their local dev chain. See docs: https://hardhat.org/config/#hardhat-network
This is helpful when testing DApps in development.