### PR TITLE
Update WalletConnect connector

### DIFF
--- a/packages/walletconnect-connector/package.json
+++ b/packages/walletconnect-connector/package.json
@@ -35,10 +35,9 @@
     "lint": "tsdx lint src"
   },
   "dependencies": {
-    "@walletconnect/web3-provider": "^1.3.6",
+    "@walletconnect/web3-provider": "^1.4.0",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
-    "tiny-invariant": "^1.0.6"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/packages/walletconnect-connector/package.json
+++ b/packages/walletconnect-connector/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@walletconnect/web3-provider": "^1.4.0",
     "@web3-react/abstract-connector": "^6.0.7",
-    "@web3-react/types": "^6.0.7",
+    "@web3-react/types": "^6.0.7"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -1,6 +1,5 @@
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
-import invariant from 'tiny-invariant'
 
 export const URI_AVAILABLE = 'URI_AVAILABLE'
 
@@ -28,7 +27,6 @@ export class WalletConnectConnector extends AbstractConnector {
   public walletConnectProvider?: any
 
   constructor({ rpc, bridge, qrcode, pollingInterval }: WalletConnectConnectorArguments) {
-    invariant(Object.keys(rpc).length === 1, '@walletconnect/web3-provider is broken with >1 chainId, please use 1')
     super({ supportedChainIds: Object.keys(rpc).map(k => Number(k)) })
 
     this.rpc = rpc


### PR DESCRIPTION
Changelog:
* remove error where rpc map can only have a single key
* update WalletConnect web3-provider package to 1.4.0