### PR TITLE
Allow to use wallet connect with any network

### DIFF
--- a/packages/walletconnect-connector/package.json
+++ b/packages/walletconnect-connector/package.json
@@ -35,7 +35,7 @@
     "lint": "tsdx lint src"
   },
   "dependencies": {
-    "@walletconnect/web3-provider": "^1.3.6",
+    "@walletconnect/web3-provider": "^1.4.1",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
     "tiny-invariant": "^1.0.6"

--- a/packages/walletconnect-connector/src/declarations.ts
+++ b/packages/walletconnect-connector/src/declarations.ts
@@ -1,3 +1,1 @@
 declare const __DEV__: boolean
-
-declare module '@walletconnect/web3-provider'

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -1,8 +1,13 @@
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
-import invariant from 'tiny-invariant'
+// import invariant from 'tiny-invariant'
+import { IWalletConnectProviderOptions } from '@walletconnect/types'
 
 export const URI_AVAILABLE = 'URI_AVAILABLE'
+
+export interface WalletConnectConnectorArguments extends IWalletConnectProviderOptions {
+  supportedChainIds?: number[];
+}
 
 export class UserRejectedRequestError extends Error {
   public constructor() {
@@ -12,29 +17,24 @@ export class UserRejectedRequestError extends Error {
   }
 }
 
-interface WalletConnectConnectorArguments {
-  rpc: { [chainId: number]: string }
-  bridge?: string
-  qrcode?: boolean
-  pollingInterval?: number
+function getSupportedChains({ supportedChainIds, rpc }: WalletConnectConnectorArguments): number[] | undefined {
+  if (supportedChainIds) {
+    return supportedChainIds
+  }
+  
+  return rpc ? Object.keys(rpc).map(k => Number(k)) : undefined
 }
 
+
 export class WalletConnectConnector extends AbstractConnector {
-  private readonly rpc: { [chainId: number]: string }
-  private readonly bridge?: string
-  private readonly qrcode?: boolean
-  private readonly pollingInterval?: number
+  private readonly config: WalletConnectConnectorArguments
 
   public walletConnectProvider?: any
 
-  constructor({ rpc, bridge, qrcode, pollingInterval }: WalletConnectConnectorArguments) {
-    invariant(Object.keys(rpc).length === 1, '@walletconnect/web3-provider is broken with >1 chainId, please use 1')
-    super({ supportedChainIds: Object.keys(rpc).map(k => Number(k)) })
+  constructor(config: WalletConnectConnectorArguments) {
+    super({supportedChainIds: getSupportedChains(config) })
 
-    this.rpc = rpc
-    this.bridge = bridge
-    this.qrcode = qrcode
-    this.pollingInterval = pollingInterval
+    this.config = config
 
     this.handleChainChanged = this.handleChainChanged.bind(this)
     this.handleAccountsChanged = this.handleAccountsChanged.bind(this)
@@ -74,17 +74,14 @@ export class WalletConnectConnector extends AbstractConnector {
   public async activate(): Promise<ConnectorUpdate> {
     if (!this.walletConnectProvider) {
       const WalletConnectProvider = await import('@walletconnect/web3-provider').then(m => m?.default ?? m)
-      this.walletConnectProvider = new WalletConnectProvider({
-        bridge: this.bridge,
-        rpc: this.rpc,
-        qrcode: this.qrcode,
-        pollingInterval: this.pollingInterval
-      })
+      this.walletConnectProvider = new WalletConnectProvider(this.config)
     }
 
     // ensure that the uri is going to be available, and emit an event if there's a new uri
     if (!this.walletConnectProvider.wc.connected) {
-      await this.walletConnectProvider.wc.createSession({ chainId: Number(Object.keys(this.rpc)[0]) })
+      await this.walletConnectProvider.wc.createSession({
+        chainId: this.supportedChainIds && this.supportedChainIds.length > 0 ? this.supportedChainIds[0] : 1
+      })
       this.emit(URI_AVAILABLE, this.walletConnectProvider.wc.uri)
     }
 

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -6,7 +6,7 @@ import { IWalletConnectProviderOptions } from '@walletconnect/types'
 export const URI_AVAILABLE = 'URI_AVAILABLE'
 
 export interface WalletConnectConnectorArguments extends IWalletConnectProviderOptions {
-  supportedChainIds?: number[];
+  supportedChainIds?: number[]
 }
 
 export class UserRejectedRequestError extends Error {
@@ -21,10 +21,9 @@ function getSupportedChains({ supportedChainIds, rpc }: WalletConnectConnectorAr
   if (supportedChainIds) {
     return supportedChainIds
   }
-  
+
   return rpc ? Object.keys(rpc).map(k => Number(k)) : undefined
 }
-
 
 export class WalletConnectConnector extends AbstractConnector {
   private readonly config: WalletConnectConnectorArguments
@@ -32,7 +31,7 @@ export class WalletConnectConnector extends AbstractConnector {
   public walletConnectProvider?: any
 
   constructor(config: WalletConnectConnectorArguments) {
-    super({supportedChainIds: getSupportedChains(config) })
+    super({ supportedChainIds: getSupportedChains(config) })
 
     this.config = config
 


### PR DESCRIPTION
This PR adds support for any network to wallet connect connector. Additionally, exposes all the available config from wallet connect, so you can have more flexibility.

Closes #152 


## Motivation
Wallet Connect can be used with any network, as shown in https://docs.walletconnect.org/quick-start/dapps/web3-provider#setup

However, the current implementation of the connector was only allowing its use in Mainnet: https://github.com/NoahZinsmeister/web3-react/blob/v6/packages/walletconnect-connector/src/index.ts#L31

## New parametrization
Now you can construct the connector using `IWalletConnectProviderOptions` which has all wallet connect parameters.

```ts
// We can specify any other network
const provider = new WalletConnectConnector({
 rpc: {
    1: "https://mainnet.mycustomnode.com",
    3: "https://ropsten.mycustomnode.com",
    100: "https://dai.poa.network",
    // ...
  },
});
```


Additionally, it adds on top of these parameters an optional `supportedChainIds?: number[]` parameter, that allows you to configure the connector without setting the optional `rpc` object parameter. This can be helpful if for example you want to specify a list of supported chains, but you prefer to setup wallet connect just by providing the infura ID:

```ts
const provider = new WalletConnectConnector({
  infuraId: "27e484dcd9e3efcfd25a83a78777cdf1",
  supportedChainIds: [1, 4, 100]
});
```

`supportedChainIds` is however optional, and it will default to mainnet, when creating a WC session. 