### PR TITLE
Added Polygon network support to magic-connector

### DIFF
--- a/packages/magic-connector/src/index.ts
+++ b/packages/magic-connector/src/index.ts
@@ -2,13 +2,26 @@ import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import invariant from 'tiny-invariant'
 
-type NetworkName = 'mainnet' | 'ropsten' | 'rinkeby' | 'kovan'
+interface CustomNodeOptions {
+  rpcUrl: string
+  chainId: number
+}
+
+type NetworkName = 'mainnet' | 'ropsten' | 'rinkeby' | 'kovan' | CustomNodeOptions
 
 const chainIdToNetwork: { [network: number]: NetworkName } = {
   1: 'mainnet',
   3: 'ropsten',
   4: 'rinkeby',
-  42: 'kovan'
+  42: 'kovan',
+  137: {
+    rpcUrl: 'https://rpc-mainnet.maticvigil.com/',
+    chainId: 137,
+  },
+  80001: {
+    rpcUrl: 'https://rpc-mumbai.maticvigil.com/',
+    chainId: 80001,
+  },
 }
 
 interface MagicConnectorArguments {
@@ -67,7 +80,7 @@ export class MagicConnector extends AbstractConnector {
   }
 
   public async activate(): Promise<ConnectorUpdate> {
-    const MagicSDK = await import('magic-sdk').then(m => m?.default ?? m)
+    const MagicSDK = await import('magic-sdk').then((m) => m?.default ?? m)
     const { Magic, RPCError, RPCErrorCode } = MagicSDK
 
     if (!this.magic) {

--- a/packages/magic-connector/src/index.ts
+++ b/packages/magic-connector/src/index.ts
@@ -16,12 +16,12 @@ const chainIdToNetwork: { [network: number]: NetworkName } = {
   42: 'kovan',
   137: {
     rpcUrl: 'https://rpc-mainnet.maticvigil.com/',
-    chainId: 137,
+    chainId: 137
   },
   80001: {
     rpcUrl: 'https://rpc-mumbai.maticvigil.com/',
-    chainId: 80001,
-  },
+    chainId: 80001
+  }
 }
 
 interface MagicConnectorArguments {
@@ -80,7 +80,7 @@ export class MagicConnector extends AbstractConnector {
   }
 
   public async activate(): Promise<ConnectorUpdate> {
-    const MagicSDK = await import('magic-sdk').then((m) => m?.default ?? m)
+    const MagicSDK = await import('magic-sdk').then(m => m?.default ?? m)
     const { Magic, RPCError, RPCErrorCode } = MagicSDK
 
     if (!this.magic) {


### PR DESCRIPTION
### Why is this necessary?
Currently, `magic-connector` only allows Ethereum networks. Since more dapps are going multi-chain, I think it's important to add support for other EVM compatible chains. 

To start with, I added Polygon (former Matic) to the supported networks. (mainnet and testnet)

### Implementation
I used Magic's `CustomNodeOptions` ([documentation](https://docs.magic.link/blockchains/ethereum)) to add Polygon. As a user of `web3-react` you simply need to add chainIds for Polygon: 137 for mainnet, 80001 for mumbai testnet

Another possible implementation is to expose the `CustomNodeOptions`, so that the user can add any network of choice. However, this would change the interface.

Please let me know what you think and if you'd like any changes. Thanks!