### PR TITLE
Update WalletLink to 2.1.0

### DIFF
--- a/packages/walletlink-connector/package.json
+++ b/packages/walletlink-connector/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
-    "walletlink": "^2.0.2"
+    "walletlink": "^2.1.0"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/packages/walletlink-connector/src/index.ts
+++ b/packages/walletlink-connector/src/index.ts
@@ -41,6 +41,9 @@ export class WalletLinkConnector extends AbstractConnector {
 
     const account = await this.provider.send('eth_requestAccounts').then((accounts: string[]): string => accounts[0])
 
+    this.provider.on('chainChanged', this.handleChainChanged)
+    this.provider.on('accountsChanged', this.handleAccountsChanged)
+
     return { provider: this.provider, chainId: CHAIN_ID, account: account }
   }
 
@@ -56,10 +59,27 @@ export class WalletLinkConnector extends AbstractConnector {
     return this.provider.send('eth_accounts').then((accounts: string[]): string => accounts[0])
   }
 
-  public deactivate() {}
+  public deactivate() {
+    this.provider.removeListener('chainChanged', this.handleChainChanged)
+    this.provider.removeListener('accountsChanged', this.handleAccountsChanged)
+  }
 
   public async close() {
     this.provider.close()
     this.emitDeactivate()
+  }
+
+  private handleChainChanged(chainId: number | string): void {
+    if (__DEV__) {
+      console.log("Handling 'chainChanged' event with payload", chainId)
+    }
+    this.emitUpdate({ chainId })
+  }
+
+  private handleAccountsChanged(accounts: string[]): void {
+    if (__DEV__) {
+      console.log("Handling 'accountsChanged' event with payload", accounts)
+    }
+    this.emitUpdate({ account: accounts[0] })
   }
 }


### PR DESCRIPTION
This PR updates WalletLink to the latest version (2.1.0) and adds event listeners for the `chainChanged` and `accountsChanged` events.