### PR TITLE
Ledger: WebHid transport if supported, use BIP44 address standard

### DIFF
--- a/packages/ledger-connector/package.json
+++ b/packages/ledger-connector/package.json
@@ -36,8 +36,10 @@
   },
   "dependencies": {
     "@0x/subproviders": "^5.0.4",
+    "@ledgerhq/hw-transport-webhid": "^5.51.1",
     "@web3-react/abstract-connector": "^6.0.7",
-    "@web3-react/types": "^6.0.7"
+    "@web3-react/types": "^6.0.7",
+    "ethereumjs-tx": "^2.1.2"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/packages/ledger-connector/src/declarations.ts
+++ b/packages/ledger-connector/src/declarations.ts
@@ -1,1 +1,2 @@
 declare module 'web3-provider-engine/subproviders/cache.js'
+declare module '@ledgerhq/hw-transport-webhid'

--- a/packages/ledger-connector/src/index.ts
+++ b/packages/ledger-connector/src/index.ts
@@ -3,7 +3,7 @@ import { AbstractConnector } from '@web3-react/abstract-connector'
 import Web3ProviderEngine from 'web3-provider-engine'
 import CacheSubprovider from 'web3-provider-engine/subproviders/cache.js'
 import { RPCSubprovider } from '@0x/subproviders/lib/src/subproviders/rpc_subprovider' // https://github.com/0xProject/0x-monorepo/issues/1400
-import { LedgerSubprovider } from 'subprovider'
+import { LedgerSubprovider } from './subprovider'
 
 interface LedgerConnectorArguments {
   chainId: number

--- a/packages/ledger-connector/src/index.ts
+++ b/packages/ledger-connector/src/index.ts
@@ -1,10 +1,9 @@
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import Web3ProviderEngine from 'web3-provider-engine'
-import { ledgerEthereumBrowserClientFactoryAsync } from '@0x/subproviders/lib/src' // https://github.com/0xProject/0x-monorepo/issues/1400
-import { LedgerSubprovider } from '@0x/subproviders/lib/src/subproviders/ledger' // https://github.com/0xProject/0x-monorepo/issues/1400
 import CacheSubprovider from 'web3-provider-engine/subproviders/cache.js'
 import { RPCSubprovider } from '@0x/subproviders/lib/src/subproviders/rpc_subprovider' // https://github.com/0xProject/0x-monorepo/issues/1400
+import { LedgerSubprovider } from 'subprovider'
 
 interface LedgerConnectorArguments {
   chainId: number
@@ -20,7 +19,6 @@ export class LedgerConnector extends AbstractConnector {
   private readonly url: string
   private readonly pollingInterval?: number
   private readonly requestTimeoutMs?: number
-  private readonly accountFetchingConfigs?: any
   private readonly baseDerivationPath?: string
 
   private provider: any
@@ -30,7 +28,6 @@ export class LedgerConnector extends AbstractConnector {
     url,
     pollingInterval,
     requestTimeoutMs,
-    accountFetchingConfigs,
     baseDerivationPath
   }: LedgerConnectorArguments) {
     super({ supportedChainIds: [chainId] })
@@ -39,7 +36,6 @@ export class LedgerConnector extends AbstractConnector {
     this.url = url
     this.pollingInterval = pollingInterval
     this.requestTimeoutMs = requestTimeoutMs
-    this.accountFetchingConfigs = accountFetchingConfigs
     this.baseDerivationPath = baseDerivationPath
   }
 
@@ -49,8 +45,6 @@ export class LedgerConnector extends AbstractConnector {
       engine.addProvider(
         new LedgerSubprovider({
           networkId: this.chainId,
-          ledgerEthereumClientFactoryAsync: ledgerEthereumBrowserClientFactoryAsync,
-          accountFetchingConfigs: this.accountFetchingConfigs,
           baseDerivationPath: this.baseDerivationPath
         })
       )
@@ -73,7 +67,7 @@ export class LedgerConnector extends AbstractConnector {
   }
 
   public async getAccount(): Promise<null> {
-    return this.provider._providers[0].getAccountsAsync(1).then((accounts: string[]): string => accounts[0])
+    return (await this.provider._providers[0].getAccountsAsync(1))[0]
   }
 
   public deactivate() {

--- a/packages/ledger-connector/src/subprovider.ts
+++ b/packages/ledger-connector/src/subprovider.ts
@@ -1,0 +1,181 @@
+import { BaseWalletSubprovider } from "@0x/subproviders/lib/src/subproviders/base_wallet_subprovider"
+import { PartialTxParams } from "@0x/subproviders"
+import { Transaction } from "ethereumjs-tx"
+import { WalletSubproviderErrors } from "@0x/subproviders/lib/src/types"
+import { stripHexPrefix } from "ethereumjs-util"
+import AppEth from "@ledgerhq/hw-app-eth"
+import TransportHID from "@ledgerhq/hw-transport-webhid"
+import TransportU2F from "@ledgerhq/hw-transport-u2f"
+
+const getTransport = () => {
+  // web hid supported
+  if ("hid" in navigator) {
+    return TransportHID.create()
+  }
+  // try U2F
+  return TransportU2F.create()
+};
+
+/**
+ * Subprovider for interfacing with a user's [Ledger Nano S](https://www.ledgerwallet.com/products/ledger-nano-s).
+ * This subprovider intercepts all account related RPC requests (e.g message/transaction signing, etc...) and
+ * re-routes them to a Ledger device plugged into the users computer.
+ */
+export class LedgerSubprovider extends BaseWalletSubprovider {
+  private readonly _networkId: number
+  private _baseDerivationPath: string
+  public selectedAccountIndex: number = 0
+
+  /**
+   * Instantiates a LedgerSubprovider. Defaults to derivationPath set to `44'/60'/x'`.
+   * TestRPC/Ganache defaults to `m/44'/60'/x'/0`, so set this in the configs if desired.
+   * @param config Several available configurations
+   * @return LedgerSubprovider instance
+   */
+  constructor({
+    networkId,
+    baseDerivationPath,
+  }: {
+    networkId: number
+    baseDerivationPath?: string
+  }) {
+    super()
+    this._networkId = networkId
+    this._baseDerivationPath = baseDerivationPath || "m/44'/60'/x'/0"
+  }
+  /**
+   * Retrieve the set derivation path
+   * @returns derivation path
+   */
+  public getPath(): string {
+    return this._baseDerivationPath
+  }
+  /**
+   * Set a desired derivation path when computing the available user addresses
+   * @param basDerivationPath The desired derivation path (e.g `44'/60'/0'`)
+   */
+  public setPath(basDerivationPath: string): void {
+    this._baseDerivationPath = basDerivationPath
+  }
+  /**
+   * Retrieve a users Ledger accounts. The accounts are derived from the derivationPath,
+   * master public key and chain code. Because of this, you can request as many accounts
+   * as you wish and it only requires a single request to the Ledger device. This method
+   * is automatically called when issuing a `eth_accounts` JSON RPC request via your providerEngine
+   * instance.
+   * @param numberOfAccounts Number of accounts to retrieve (default: 10)
+   * @param from
+   * @return An array of accounts
+   */
+  public async getAccountsAsync(
+    numberOfAccounts: number = 10,
+    from: number = 0,
+  ): Promise<string[]> {
+    const addresses = []
+    let transport = await getTransport()
+    try {
+      const eth = new AppEth(transport)
+      for (let i = from; i < from + numberOfAccounts; i++) {
+        const path = this._baseDerivationPath.replace("x", String(i))
+        const info = await eth.getAddress(path, false, true)
+        addresses.push(info.address)
+      }
+    } catch (e) {
+      console.log(e)
+    } finally {
+      await transport.close()
+    }
+    return addresses
+  }
+
+  /**
+   * Signs a transaction on the Ledger with the account specificed by the `from` field in txParams.
+   * If you've added the LedgerSubprovider to your app's provider, you can simply send an `eth_sendTransaction`
+   * JSON RPC request, and this method will be called auto-magically. If you are not using this via a ProviderEngine
+   * instance, you can call it directly.
+   * @param txParams Parameters of the transaction to sign
+   * @return Signed transaction hex string
+   */
+  public async signTransactionAsync(txParams: PartialTxParams): Promise<string> {
+    const path = this._baseDerivationPath.replace("x", this.selectedAccountIndex.toString())
+    if (!path) throw new Error("address unknown '" + txParams.from + "'")
+    let transport = await getTransport()
+    try {
+      const eth = new AppEth(transport)
+      const tx = new Transaction(txParams, { chain: this._networkId })
+
+      // Set the EIP155 bits
+      tx.raw[6] = Buffer.from([this._networkId]) // v
+      tx.raw[7] = Buffer.from([]) // r
+      tx.raw[8] = Buffer.from([]) // s
+
+      // Pass hex-rlp to ledger for signing
+      const result = await eth.signTransaction(path, tx.serialize().toString("hex"))
+
+      // Store signature in transaction
+      tx.v = Buffer.from(result.v, "hex")
+      tx.r = Buffer.from(result.r, "hex")
+      tx.s = Buffer.from(result.s, "hex")
+
+      // EIP155: v should be chain_id * 2 + {35, 36}
+      const signedChainId = Math.floor((tx.v[0] - 35) / 2)
+      const validChainId = this._networkId & 0xff; // FIXME this is to fixed a current workaround that app don't support > 0xff
+      if (signedChainId !== validChainId) {
+        throw LedgerSubprovider.makeError(
+          "Invalid networkId signature returned. Expected: " +
+            this._networkId +
+            ", Got: " +
+            signedChainId,
+          "InvalidNetworkId",
+        )
+      }
+
+      return `0x${tx.serialize().toString("hex")}`
+    } finally {
+      await transport.close()
+    }
+  }
+
+  private static makeError(msg: string | undefined, id: string) {
+    const err = new Error(msg)
+    // @ts-ignore
+    err.id = id
+    return err
+  }
+
+  /**
+   * Sign a personal Ethereum signed message. The signing account will be the account
+   * associated with the provided address.
+   * The Ledger adds the Ethereum signed message prefix on-device.  If you've added
+   * the LedgerSubprovider to your app's provider, you can simply send an `eth_sign`
+   * or `personal_sign` JSON RPC request, and this method will be called auto-magically.
+   * If you are not using this via a ProviderEngine instance, you can call it directly.
+   * @param data Hex string message to sign
+   * @param address Address of the account to sign with
+   * @return Signature hex string (order: rsv)
+   */
+  public async signPersonalMessageAsync(data: string, address: string): Promise<string> {
+    const path = this._baseDerivationPath.replace("x", this.selectedAccountIndex.toString())
+    if (!path) throw new Error("address unknown '" + address + "'")
+    let transport = await getTransport()
+    try {
+      const eth = new AppEth(transport)
+      const result = await eth.signPersonalMessage(path, stripHexPrefix(data))
+      const v = parseInt(result.v.toString(), 10) - 27
+      let vHex = v.toString(16)
+      if (vHex.length < 2) {
+        vHex = `0${v}`
+      }
+      return `0x${result.r}${result.s}${vHex}`
+    } finally {
+      await transport.close()
+    }
+  }
+  /**
+   * eth_signTypedData is currently not supported on Ledger devices.
+   * @return Signature hex string (order: rsv)
+   */
+  public async signTypedDataAsync(): Promise<string> {
+    throw new Error(WalletSubproviderErrors.MethodNotSupported)
+  }
+}

--- a/packages/ledger-connector/yarn.lock
+++ b/packages/ledger-connector/yarn.lock
@@ -287,10 +287,25 @@
     "@ledgerhq/logs" "^4.72.0"
     rxjs "^6.5.3"
 
+"@ledgerhq/devices@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
+  integrity sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==
+  dependencies:
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/logs" "^5.50.0"
+    rxjs "6"
+    semver "^7.3.5"
+
 "@ledgerhq/errors@^4.78.0":
   version "4.78.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.78.0.tgz#23daf3af54d03b1bda3e616002b555da1bdb705a"
   integrity sha512-FX6zHZeiNtegBvXabK6M5dJ+8OV8kQGGaGtuXDeK/Ss5EmG4Ltxc6Lnhe8hiHpm9pCHtktOsnUVL7IFBdHhYUg==
+
+"@ledgerhq/errors@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.50.0.tgz#e3a6834cb8c19346efca214c1af84ed28e69dad9"
+  integrity sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==
 
 "@ledgerhq/hw-app-eth@^4.3.0":
   version "4.78.0"
@@ -333,6 +348,16 @@
     "@ledgerhq/hw-transport" "^4.24.0"
     u2f-api "0.2.7"
 
+"@ledgerhq/hw-transport-webhid@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-5.51.1.tgz#2050d65ef4ce179e8f43cd7245b811d8f05fdcfc"
+  integrity sha512-w/2qSU0vwFY+D/4ucuYRViO7iS3Uuxmj9sI/Iiqkoiax9Xppb0/6H5m3ffKv6iPMmRYbgwCgXorqx4SLLSD8Kg==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/hw-transport" "^5.51.1"
+    "@ledgerhq/logs" "^5.50.0"
+
 "@ledgerhq/hw-transport@^4.24.0", "@ledgerhq/hw-transport@^4.78.0":
   version "4.78.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.78.0.tgz#714786658e1f2fbc0569e06e2abf8d15d310d931"
@@ -342,10 +367,24 @@
     "@ledgerhq/errors" "^4.78.0"
     events "^3.0.0"
 
+"@ledgerhq/hw-transport@^5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz#8dd14a8e58cbee4df0c29eaeef983a79f5f22578"
+  integrity sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==
+  dependencies:
+    "@ledgerhq/devices" "^5.51.1"
+    "@ledgerhq/errors" "^5.50.0"
+    events "^3.3.0"
+
 "@ledgerhq/logs@^4.72.0":
   version "4.72.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
   integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
+
+"@ledgerhq/logs@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
+  integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -423,6 +462,18 @@
   integrity sha512-yHr8mX2SoX3JNyfqdLXdO1UobsGhfiwSgtekbVxKLQrzD7vtpPkKbkIVsPFOhvekvNbPsCmDyeDCLkpeI9gSmA==
   dependencies:
     "@types/ethereum-protocol" "*"
+
+"@web3-react/abstract-connector@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz#401b3c045f1e0fab04256311be49d5144e9badc6"
+  integrity sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==
+  dependencies:
+    "@web3-react/types" "^6.0.7"
+
+"@web3-react/types@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-6.0.7.tgz#34a6204224467eedc6123abaf55fbb6baeb2809f"
+  integrity sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -2580,6 +2631,11 @@ events@^3.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -3859,6 +3915,13 @@ lru-cache@^3.2.0:
   dependencies:
     pseudomap "^1.0.1"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 ltgt@^2.1.2, ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -4916,6 +4979,13 @@ rustbn.js@~0.2.0:
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
+rxjs@6:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
 rxjs@^6.5.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
@@ -5011,6 +5081,13 @@ semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@~5.4.1:
   version "5.4.1"
@@ -6198,3 +6275,8 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
### What does this PR do?

- Use WebHid transport if available and U2F as a fallback, recently the latest chrome  removed the U2F which lead to the ledger subprovider used in many libraries to stop working, see: https://twitter.com/MetaMask/status/1397659854446022656
- Use BIP44 Address standard, see: https://github.com/ethereum/EIPs/issues/84

Note you need to accept hid device from chrome UI: 

<img width="882" alt="Screenshot 2021-06-02 at 6 12 38 PM" src="https://user-images.githubusercontent.com/5216291/120463139-2ec0d200-c3ce-11eb-989a-0a37512e980c.png">

You can already test the ledger connector on our website https://mimo.capital/  :) 
