### PR TITLE
Replaced legacy send with request

### DIFF
--- a/packages/injected-connector/src/declarations.ts
+++ b/packages/injected-connector/src/declarations.ts
@@ -1,8 +1,19 @@
 interface Ethereum {
-  send: unknown
+  request: (args: RequestArguments) => Promise<unknown>
   enable: () => Promise<string[]>
   on?: (method: string, listener: (...args: any[]) => void) => void
   removeListener?: (method: string, listener: (...args: any[]) => void) => void
+  isMetaMask: boolean
+  chainId: any
+  netVersion: any
+  networkVersion: any
+  _chainId: any
+  autoRefreshOnNetworkChange: boolean
+}
+
+export interface RequestArguments {
+    method: string;
+    params?: unknown[] | object;
 }
 
 declare interface Window {

--- a/packages/injected-connector/src/types.ts
+++ b/packages/injected-connector/src/types.ts
@@ -1,5 +1,4 @@
-export type SendReturnResult = { result: any }
-export type SendReturn = any
+export type RequestReturnResult = { result: any }
+export type RequestReturn = any
 
-export type Send = (method: string, params?: any[]) => Promise<SendReturnResult | SendReturn>
-export type SendOld = ({ method }: { method: string }) => Promise<SendReturnResult | SendReturn>
+

--- a/packages/injected-connector/yarn.lock
+++ b/packages/injected-connector/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@web3-react/abstract-connector@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz#401b3c045f1e0fab04256311be49d5144e9badc6"
+  integrity sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==
+  dependencies:
+    "@web3-react/types" "^6.0.7"
+
+"@web3-react/types@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-6.0.7.tgz#34a6204224467eedc6123abaf55fbb6baeb2809f"
+  integrity sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A==
+
 tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"


### PR DESCRIPTION
Replaced relacy https://docs.metamask.io/guide/ethereum-provider.html#ethereum-send-deprecated with https://docs.metamask.io/guide/ethereum-provider.html#methods