### PR TITLE
Enhancement: Return account info from activate method

### DIFF
--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -142,6 +142,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
           throw new StaleConnectorError()
         }
         dispatch({ type: ActionType.ACTIVATE_CONNECTOR, payload: { connector, ...augmentedUpdate, onError } })
+        return augmentedUpdate;
       } catch (error) {
         if (error instanceof StaleConnectorError) {
           activated && connector.deactivate()

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -124,7 +124,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
       connector: AbstractConnector,
       onError?: (error: Error) => void,
       throwErrors: boolean = false
-    ): Promise<void> => {
+    ): Promise<ConnectorUpdate<number> | undefined> => {
       const updateBusterInitial = updateBusterRef.current
 
       let activated = false
@@ -158,6 +158,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
           dispatch({ type: ActionType.ERROR_FROM_ACTIVATION, payload: { connector, error } })
         }
       }
+      return
     },
     []
   )

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -124,7 +124,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
       connector: AbstractConnector,
       onError?: (error: Error) => void,
       throwErrors: boolean = false
-    ): Promise<ConnectorUpdate<number> | undefined> => {
+    ): Promise<Web3ReactManagerState | undefined> => {
       const updateBusterInitial = updateBusterRef.current
 
       let activated = false
@@ -142,7 +142,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
           throw new StaleConnectorError()
         }
         dispatch({ type: ActionType.ACTIVATE_CONNECTOR, payload: { connector, ...augmentedUpdate, onError } })
-        return augmentedUpdate;
+        return { connector, ...augmentedUpdate }
       } catch (error) {
         if (error instanceof StaleConnectorError) {
           activated && connector.deactivate()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,12 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
+import { ConnectorUpdate } from '@web3-react/types'
 
 export interface Web3ReactManagerFunctions {
-  activate: (connector: AbstractConnector, onError?: (error: Error) => void, throwErrors?: boolean) => Promise<void>
+  activate: (
+    connector: AbstractConnector,
+    onError?: (error: Error) => void,
+    throwErrors?: boolean
+  ) => Promise<ConnectorUpdate<number> | undefined>
   setError: (error: Error) => void
   deactivate: () => void
 }


### PR DESCRIPTION
**Motivation:**
As mentioned in this issue https://github.com/NoahZinsmeister/web3-react/issues/91 nothing is currently returned when you call `activate()` as can be seen here https://github.com/NoahZinsmeister/web3-react/blob/483bc54c8a5e831e3f2ffa42b733ffbbc0fd58b2/packages/core/src/manager.ts#L144  This means that if you have complex control flows you must react to context changes in a component where it becomes difficult to extract the logic to middleware or another service since the prior context is stale. This PR returns the updated dispatched values which can be used immediately after in any control flow (in my personal case I need these values to create a new temporary wallet within redux-saga).

Edit: Other PR (https://github.com/NoahZinsmeister/web3-react/pull/230) was polluted with work for another project so I'm opening this branch to make the PR from instead