### PR TITLE
fix(state): max safe chainId

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,21 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
     '^@web3-react/(.*)$': '<rootDir>/packages/$1/src',
+  },
+  verbose: true,
+  transform: {
+    "^.+\\.tsx?$": 'ts-jest'
+  },
+  globals: {
+    'ts-jest': {
+      diagnostics: {
+        // Do not fail on TS compilation errors
+        // https://kulshekhar.github.io/ts-jest/user/config/diagnostics#do-not-fail-on-first-error
+        warnOnly: true
+      }
+    }
   },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,17 +5,4 @@ module.exports = {
   moduleNameMapper: {
     '^@web3-react/(.*)$': '<rootDir>/packages/$1/src',
   },
-  verbose: true,
-  transform: {
-    "^.+\\.tsx?$": 'ts-jest'
-  },
-  globals: {
-    'ts-jest': {
-      diagnostics: {
-        // Do not fail on TS compilation errors
-        // https://kulshekhar.github.io/ts-jest/user/config/diagnostics#do-not-fail-on-first-error
-        warnOnly: true
-      }
-    }
-  },
 }

--- a/packages/store/src/index.spec.ts
+++ b/packages/store/src/index.spec.ts
@@ -1,4 +1,4 @@
-import { ChainIdNotAllowedError, createWeb3ReactStoreAndActions } from './'
+import { ChainIdNotAllowedError, createWeb3ReactStoreAndActions, MAX_SAFE_CHAIN_ID } from './'
 
 test('ChainIdNotAllowedError', () => {
   const error = new ChainIdNotAllowedError(1, [2])
@@ -33,11 +33,10 @@ describe('#createWeb3ReactStoreAndActions', () => {
     })
   })
 
-
   describe('#update', () => {
     test('throws on bad chainIds', () => {
       const [, actions] = createWeb3ReactStoreAndActions()
-      for (const chainId of [1.1, 0, Number.MAX_SAFE_INTEGER + 1 ]) {
+      for (const chainId of [1.1, 0, MAX_SAFE_CHAIN_ID + 1]) {
         expect(() => actions.update({ chainId })).toThrow(`Invalid chainId ${chainId}`)
       }
     })

--- a/packages/store/src/index.spec.ts
+++ b/packages/store/src/index.spec.ts
@@ -33,10 +33,11 @@ describe('#createWeb3ReactStoreAndActions', () => {
     })
   })
 
+
   describe('#update', () => {
     test('throws on bad chainIds', () => {
       const [, actions] = createWeb3ReactStoreAndActions()
-      for (const chainId of [1.1, 0, Number.MAX_SAFE_INTEGER + 1]) {
+      for (const chainId of [1.1, 0, Number.MAX_SAFE_INTEGER + 1 ]) {
         expect(() => actions.update({ chainId })).toThrow(`Invalid chainId ${chainId}`)
       }
     })

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -13,10 +13,10 @@ import { getAddress } from '@ethersproject/address'
  * @see {@link https://git.io/JPBat}
  */
 
-const MAX_SAFE_CHAIN_ID = 4503599627370476
+export const MAX_SAFE_CHAIN_ID = 4503599627370476;
 
 function validateChainId(chainId: number): void {
-  if (!Number.isInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID) {
+  if (!Number.isInteger(chainId)  || chainId <= 0 || chainId > MAX_SAFE_CHAIN_ID) {
     throw new Error(`Invalid chainId ${chainId}`)
   }
 }

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,8 +2,21 @@ import type { Web3ReactState, Web3ReactStore, Web3ReactStateUpdate, Actions } fr
 import create from 'zustand/vanilla'
 import { getAddress } from '@ethersproject/address'
 
+/**
+ * @notice MAX_SAFE_CHAIN_ID establishes the upper bound limit on what can be accepted for `chainId`
+ * @summary
+ * ```
+ *   MAX_SAFE_CHAIN_ID = floor( ( 2**53 - 39 ) / 2 ) = 4503599627370476
+ * ```
+ *
+ * @const MAX_SAFE_CHAIN_ID The maximum integer value that metamask will accept as a chainId
+ * @see {@link https://git.io/JPBat}
+ */
+
+const MAX_SAFE_CHAIN_ID = 4503599627370476
+
 function validateChainId(chainId: number): void {
-  if (!Number.isInteger(chainId) || chainId <= 0 || chainId > Number.MAX_SAFE_INTEGER) {
+  if (!Number.isInteger(chainId) && chainId > 0 && chainId <= MAX_SAFE_CHAIN_ID) {
     throw new Error(`Invalid chainId ${chainId}`)
   }
 }


### PR DESCRIPTION
Metamask has a hardcoded value for rejecting chainId's over a certain number. That number is calculated based off of 

[source from remarks, metamask engineer](https://gist.github.com/rekmarks/a47bd5f2525936c4b8eee31a16345553)
```
From ethereumjs-util@7.0.5, we have that:

  v = recovery + (chainId * 2 + 35)

Per the above discussion, we also have that:

  int_max = 2**53 - 1
  recovery_max = 3
  chainId_max = ?

Therefore:

  v_max = 3 + (chainId * 2 + 35) = chainId * 2 + 38
    &&
  v_max <= int_max
  
    ->
    
  2**53 - 1 = MAX_SAFE_CHAIN_ID * 2 + 38
  
    ->
    
  // Since we're dealing with integers, we round down.
  
  MAX_SAFE_CHAIN_ID = floor( ( 2**53 - 39 ) / 2 ) = 4503599627370476
```

Ethereumjs-util as referenced above has BigInt support since 7.0.9, regardless metamask has encoded this value within their application.
[see https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.9](https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.9)

I tried to document it as best I could, I don't know how you feel about that I can remove it if you would like. 