### PR TITLE
Make activate() return ConnectorUpdate

### DIFF
--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -124,7 +124,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
       connector: AbstractConnector,
       onError?: (error: Error) => void,
       throwErrors: boolean = false
-    ): Promise<void> => {
+    ): Promise<ConnectorUpdate> => {
       const updateBusterInitial = updateBusterRef.current
 
       let activated = false
@@ -142,6 +142,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
           throw new StaleConnectorError()
         }
         dispatch({ type: ActionType.ACTIVATE_CONNECTOR, payload: { connector, ...augmentedUpdate, onError } })
+        return augmentedUpdate
       } catch (error) {
         if (error instanceof StaleConnectorError) {
           activated && connector.deactivate()
@@ -156,6 +157,7 @@ export function useWeb3ReactManager(): Web3ReactManagerReturn {
           // we don't call activated && connector.deactivate() here because it'll be handled in the useEffect
           dispatch({ type: ActionType.ERROR_FROM_ACTIVATION, payload: { connector, error } })
         }
+        throw error
       }
     },
     []

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,8 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
+import { ConnectorUpdate } from '@web3-react/types'
 
 export interface Web3ReactManagerFunctions {
-  activate: (connector: AbstractConnector, onError?: (error: Error) => void, throwErrors?: boolean) => Promise<void>
+  activate: (connector: AbstractConnector, onError?: (error: Error) => void, throwErrors?: boolean) => Promise<ConnectorUpdate>
   setError: (error: Error) => void
   deactivate: () => void
 }


### PR DESCRIPTION
This will allow getting `accounts` from a successful promise, which then may be handled by Dapps to register a new account.