### PR TITLE
fix: do not access undefined property in wc connector

### DIFF
--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -1,6 +1,7 @@
 import { IWCEthRpcConnectionOptions } from '@walletconnect/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { ConnectorUpdate } from '@web3-react/types'
+import type WalletConnectProvider from "@walletconnect/ethereum-provider";
 
 export const URI_AVAILABLE = 'URI_AVAILABLE'
 
@@ -25,7 +26,7 @@ function getSupportedChains({ supportedChainIds, rpc }: WalletConnectConnectorAr
 }
 
 export class WalletConnectConnector extends AbstractConnector {
-  public walletConnectProvider?: any
+  public walletConnectProvider?: WalletConnectProvider
   private readonly config: WalletConnectConnectorArguments
 
   constructor(config: WalletConnectConnectorArguments) {
@@ -57,7 +58,7 @@ export class WalletConnectConnector extends AbstractConnector {
     }
     // we have to do this because of a @walletconnect/web3-provider bug
     if (this.walletConnectProvider) {
-      this.walletConnectProvider.stop()
+      this.walletConnectProvider.stop?.()
       this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
       this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
       this.walletConnectProvider = undefined
@@ -72,11 +73,11 @@ export class WalletConnectConnector extends AbstractConnector {
     }
 
     // ensure that the uri is going to be available, and emit an event if there's a new uri
-    if (!this.walletConnectProvider.wc.connected) {
-      await this.walletConnectProvider.wc.createSession(
+    if (!this.walletConnectProvider.connector.connected) {
+      await this.walletConnectProvider.connector.createSession(
         this.config.chainId ? { chainId: this.config.chainId } : undefined
       )
-      this.emit(URI_AVAILABLE, this.walletConnectProvider.wc.uri)
+      this.emit(URI_AVAILABLE, this.walletConnectProvider.connector.uri)
     }
 
     let account: string
@@ -88,7 +89,7 @@ export class WalletConnectConnector extends AbstractConnector {
       }
 
       // Workaround to bubble up the error when user reject the connection
-      this.walletConnectProvider.wc.on('disconnect', () => {
+      this.walletConnectProvider.connector.on('disconnect', () => {
         // Check provider has not been enabled to prevent this event callback from being called in the future
         if (!account) {
           userReject()

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -1,7 +1,7 @@
-import { IWCEthRpcConnectionOptions } from '@walletconnect/types'
-import { AbstractConnector } from '@web3-react/abstract-connector'
-import { ConnectorUpdate } from '@web3-react/types'
 import type WalletConnectProvider from "@walletconnect/ethereum-provider";
+import { IWCEthRpcConnectionOptions } from '@walletconnect/types';
+import { AbstractConnector } from '@web3-react/abstract-connector';
+import { ConnectorUpdate } from '@web3-react/types';
 
 export const URI_AVAILABLE = 'URI_AVAILABLE'
 
@@ -58,7 +58,6 @@ export class WalletConnectConnector extends AbstractConnector {
     }
     // we have to do this because of a @walletconnect/web3-provider bug
     if (this.walletConnectProvider) {
-      this.walletConnectProvider.stop?.()
       this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
       this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
       this.walletConnectProvider = undefined
@@ -89,14 +88,14 @@ export class WalletConnectConnector extends AbstractConnector {
       }
 
       // Workaround to bubble up the error when user reject the connection
-      this.walletConnectProvider.connector.on('disconnect', () => {
+      this.walletConnectProvider!.connector.on('disconnect', () => {
         // Check provider has not been enabled to prevent this event callback from being called in the future
         if (!account) {
           userReject()
         }
       })
 
-      this.walletConnectProvider
+      this.walletConnectProvider!
         .enable()
         .then((accounts: string[]) => resolve(accounts[0]))
         .catch((error: Error): void => {
@@ -123,11 +122,11 @@ export class WalletConnectConnector extends AbstractConnector {
   }
 
   public async getChainId(): Promise<number | string> {
-    return Promise.resolve(this.walletConnectProvider.chainId)
+    return Promise.resolve(this.walletConnectProvider!.chainId)
   }
 
   public async getAccount(): Promise<null | string> {
-    return Promise.resolve(this.walletConnectProvider.accounts).then((accounts: string[]): string => accounts[0])
+    return Promise.resolve(this.walletConnectProvider!.accounts).then((accounts: string[]): string => accounts[0])
   }
 
   public deactivate() {

--- a/packages/walletconnect-connector/src/index.ts
+++ b/packages/walletconnect-connector/src/index.ts
@@ -1,7 +1,7 @@
-import type WalletConnectProvider from "@walletconnect/ethereum-provider";
-import { IWCEthRpcConnectionOptions } from '@walletconnect/types';
-import { AbstractConnector } from '@web3-react/abstract-connector';
-import { ConnectorUpdate } from '@web3-react/types';
+import WalletConnectProvider from '@walletconnect/ethereum-provider'
+import { IWCEthRpcConnectionOptions } from '@walletconnect/types'
+import { AbstractConnector } from '@web3-react/abstract-connector'
+import { ConnectorUpdate } from '@web3-react/types'
 
 export const URI_AVAILABLE = 'URI_AVAILABLE'
 
@@ -95,8 +95,7 @@ export class WalletConnectConnector extends AbstractConnector {
         }
       })
 
-      this.walletConnectProvider!
-        .enable()
+      this.walletConnectProvider!.enable()
         .then((accounts: string[]) => resolve(accounts[0]))
         .catch((error: Error): void => {
           // TODO ideally this would be a better check


### PR DESCRIPTION
hello,
this PR changes some code that was introduced recently in https://github.com/NoahZinsmeister/web3-react/pull/360/files

I'm not sure how the code was tested but for me, it just does not work - eg. calling `this.walletConnectProvider.wc.connected` gives me `Cannot read property 'connected' of undefined`

Indeed, if you check the source [code](https://github.com/WalletConnect/walletconnect-monorepo/blob/1.7.1/packages/providers/ethereum-provider/src/index.ts) of `@walletconnect/ethereum-provider` at the respective version, there is no `wc` property so the call is bound to fail.

I have replaced the occurrences of `this.walletConnectProvider.wc` by `this.walletConnectProvider.connector` which seems to be the appropriate property. There is a `wc` property that can be accessed under `this.walletConnectProvider.signer.connection.wc`, maybe that is what was meant to be used? See:

<img width="627" alt="Screen Shot 2022-02-15 at 11 06 33" src="https://user-images.githubusercontent.com/94828212/153991068-d0a8a379-9282-4861-b8e3-e54ece6d5239.png">


also did a small change of `this.walletConnectProvider.stop()` to `this.walletConnectProvider.stop?.()`

because after adding the type to `walletConnectProvider`, there is this TS error

<img width="763" alt="Screen Shot 2022-02-15 at 10 40 33" src="https://user-images.githubusercontent.com/94828212/153990891-aadc2576-07ec-4dae-baa8-5e1e60d4620a.png">

this might be a bug but if confirmed, I'll fix it in another PR.

Thank you