### PR TITLE
fix: upgrade walletlink to `@coinbase/wallet-sdk`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepack": "yarn build"
   },
   "devDependencies": {
+    "@coinbase/wallet-sdk": "^3.0.1",
     "@testing-library/react-hooks": "^7.0.2",
     "@tsconfig/recommended": "^1.0.1",
     "@types/jest": "^27.0.2",
@@ -34,7 +35,6 @@
     "react": "^17.0.2",
     "react-test-renderer": "^17.0.2",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.5.4",
-    "walletlink": "^2.4.5"
+    "typescript": "^4.5.4"
   }
 }

--- a/packages/walletlink/package.json
+++ b/packages/walletlink/package.json
@@ -27,7 +27,7 @@
     "@web3-react/types": "^8.0.10-beta.0"
   },
   "peerDependencies": {
-    "@coinbase/wallet-sdk": "3.0.1"
+    "@coinbase/wallet-sdk": "^3.0.1"
   },
   "devDependencies": {
     "@web3-react/store": "^8.0.13-beta.0"

--- a/packages/walletlink/package.json
+++ b/packages/walletlink/package.json
@@ -27,7 +27,7 @@
     "@web3-react/types": "^8.0.10-beta.0"
   },
   "peerDependencies": {
-    "walletlink": "^2.4.5"
+    "@coinbase/wallet-sdk": "3.0.1"
   },
   "devDependencies": {
     "@web3-react/store": "^8.0.13-beta.0"

--- a/packages/walletlink/src/index.spec.ts
+++ b/packages/walletlink/src/index.spec.ts
@@ -3,7 +3,7 @@ import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { WalletLink } from '.'
 import { MockEIP1193Provider } from '../../eip1193/src/index.spec'
 
-jest.mock('walletlink', () => ({
+jest.mock('@coinbase/wallet-sdk', () => ({
   WalletLink: class MockWalletLink {
     makeWeb3Provider() {
       return new MockEIP1193Provider()

--- a/packages/walletlink/src/index.spec.ts
+++ b/packages/walletlink/src/index.spec.ts
@@ -3,13 +3,15 @@ import type { Actions, Web3ReactStore } from '@web3-react/types'
 import { WalletLink } from '.'
 import { MockEIP1193Provider } from '../../eip1193/src/index.spec'
 
-jest.mock('@coinbase/wallet-sdk', () => ({
-  WalletLink: class MockWalletLink {
-    makeWeb3Provider() {
-      return new MockEIP1193Provider()
+jest.mock(
+  '@coinbase/wallet-sdk',
+  () =>
+    class MockWalletLink {
+      makeWeb3Provider() {
+        return new MockEIP1193Provider()
+      }
     }
-  },
-}))
+)
 
 const chainId = '0x1'
 const accounts: string[] = []

--- a/packages/walletlink/src/index.ts
+++ b/packages/walletlink/src/index.ts
@@ -45,7 +45,7 @@ export class WalletLink extends Connector {
 
     await (this.eagerConnection = import('@coinbase/wallet-sdk').then((m) => {
       const { url, ...options } = this.options
-      this.walletLink = new m.CoinbaseWalletSDK(options)
+      this.walletLink = new (m.default ?? m.CoinbaseWalletSDK)(options)
       this.provider = this.walletLink.makeWeb3Provider(url)
 
       this.provider.on('connect', ({ chainId }: ProviderConnectInfo): void => {

--- a/packages/walletlink/src/index.ts
+++ b/packages/walletlink/src/index.ts
@@ -1,7 +1,7 @@
 import type { Actions, AddEthereumChainParameter, ProviderConnectInfo, ProviderRpcError } from '@web3-react/types'
 import { Connector } from '@web3-react/types'
-import type { WalletLink as WalletLinkInstance } from 'walletlink'
-import type { WalletLinkOptions } from 'walletlink/dist/WalletLink'
+import type { CoinbaseWalletSDK, CoinbaseWalletProvider } from '@coinbase/wallet-sdk'
+import type { CoinbaseWalletSDKOptions } from '@coinbase/wallet-sdk/dist/CoinbaseWalletSDK'
 
 function parseChainId(chainId: string | number) {
   return typeof chainId === 'number' ? chainId : Number.parseInt(chainId, chainId.startsWith('0x') ? 16 : 10)
@@ -9,21 +9,21 @@ function parseChainId(chainId: string | number) {
 
 export class WalletLink extends Connector {
   /** {@inheritdoc Connector.provider} */
-  public provider: ReturnType<WalletLinkInstance['makeWeb3Provider']> | undefined
+  public provider: CoinbaseWalletProvider | undefined
 
-  private readonly options: WalletLinkOptions & { url: string }
+  private readonly options: CoinbaseWalletSDKOptions & { url: string }
   private eagerConnection?: Promise<void>
 
   /**
    * A `walletlink` instance.
    */
-  public walletLink: WalletLinkInstance | undefined
+  public walletLink: CoinbaseWalletSDK | undefined
 
   /**
    * @param options - Options to pass to `walletlink`
    * @param connectEagerly - A flag indicating whether connection should be initiated when the class is constructed.
    */
-  constructor(actions: Actions, options: WalletLinkOptions & { url: string }, connectEagerly = false) {
+  constructor(actions: Actions, options: CoinbaseWalletSDKOptions & { url: string }, connectEagerly = false) {
     super(actions)
 
     if (connectEagerly && typeof window === 'undefined') {
@@ -43,9 +43,9 @@ export class WalletLink extends Connector {
   private async isomorphicInitialize(): Promise<void> {
     if (this.eagerConnection) return this.eagerConnection
 
-    await (this.eagerConnection = import('walletlink').then((m) => {
+    await (this.eagerConnection = import('@coinbase/wallet-sdk').then((m) => {
       const { url, ...options } = this.options
-      this.walletLink = new m.WalletLink(options)
+      this.walletLink = new m.CoinbaseWalletSDK(options)
       this.provider = this.walletLink.makeWeb3Provider(url)
 
       this.provider.on('connect', ({ chainId }: ProviderConnectInfo): void => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,25 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@coinbase/wallet-sdk@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-3.0.1.tgz#799b10e12f484caa8d2aefe3b4b7bc4ae13e996d"
+  integrity sha512-wHCoOhT7/34xK2XKRvOBA2ZINsrQLbkLftvN31RwHtscHy21B8AGBbhxetUdJvOeBTqAxQKwWTDKYxvl2Rn5gg==
+  dependencies:
+    "@metamask/safe-event-emitter" "2.0.0"
+    bind-decorator "^1.0.11"
+    bn.js "^5.1.1"
+    clsx "^1.1.0"
+    eth-block-tracker "4.4.3"
+    eth-json-rpc-filters "4.2.2"
+    eth-rpc-errors "4.0.2"
+    js-sha256 "0.9.0"
+    json-rpc-engine "6.1.0"
+    keccak "^3.0.1"
+    preact "^10.5.9"
+    rxjs "^6.6.3"
+    stream-browserify "^3.0.0"
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
@@ -8069,25 +8088,6 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-walletlink@^2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/walletlink/-/walletlink-2.4.5.tgz#551ecec6589bf18fa2bc57252e47102aa58e6693"
-  integrity sha512-gt4z9E+OT4fbTmoetsB3q8FlN3jrVxW2l9TbipyKo4HfgPezKQKZAs/6jk2RI3JA4wykAYmMdj2C4+uYDFSvKw==
-  dependencies:
-    "@metamask/safe-event-emitter" "2.0.0"
-    bind-decorator "^1.0.11"
-    bn.js "^5.1.1"
-    clsx "^1.1.0"
-    eth-block-tracker "4.4.3"
-    eth-json-rpc-filters "4.2.2"
-    eth-rpc-errors "4.0.2"
-    js-sha256 "0.9.0"
-    json-rpc-engine "6.1.0"
-    keccak "^3.0.1"
-    preact "^10.5.9"
-    rxjs "^6.6.3"
-    stream-browserify "^3.0.0"
 
 wcwidth@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
`walletlink` became deprecated and has been moved to [@coinbase/wallet-sdk](http://npmjs.com/@coinbase/wallet-sdk). This PR replaces all the imports.

