### PR TITLE
fix(coinbase): declare provider

### DIFF
--- a/packages/coinbase-wallet/src/index.ts
+++ b/packages/coinbase-wallet/src/index.ts
@@ -10,7 +10,7 @@ type CoinbaseWalletSDKOptions = ConstructorParameters<typeof CoinbaseWalletSDK>[
 
 export class CoinbaseWallet extends Connector {
   /** {@inheritdoc Connector.provider} */
-  public provider: CoinbaseWalletProvider | undefined
+  declare public provider: CoinbaseWalletProvider | undefined;
 
   private readonly options: CoinbaseWalletSDKOptions
   private eagerConnection?: Promise<void>


### PR DESCRIPTION
Property 'provider' will overwrite the base property in 'Connector' if not declared