### PR TITLE
Add ethereum-cryptography to walletlink-connector package.json

### DIFF
--- a/packages/walletlink-connector/package.json
+++ b/packages/walletlink-connector/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
+    "ethereum-cryptography": "^1.0.3",
     "walletlink": "^2.5.0"
   },
   "license": "GPL-3.0-or-later"


### PR DESCRIPTION
When installed with     
"@web3-react/core": "^6.1.9",
"@web3-react/injected-connector": "^6.0.7",
"@web3-react/portis-connector": "^6.2.11",
"@web3-react/walletconnect-connector": "^6.2.13"

using NextJS

I get an error saying that 'node_modules/ethereum-cryptography/node_modules/keccak/js.js' file is missing. It is fixed once adding 'ethereum-cryptography' manually and remains fixed even if I manually remove 'ethereum-cryptography' afterwards. I assume adding this dependency would fix this issue in the future.