### PR TITLE
fix(metamask): don't report error if users denies network change request

### DIFF
--- a/packages/metamask/src/index.ts
+++ b/packages/metamask/src/index.ts
@@ -160,7 +160,12 @@ export class MetaMask extends Connector {
           .then(() => this.activate(desiredChainId))
       })
       .catch((error: ProviderRpcError) => {
-        this.actions.reportError(error)
+        if (error.code === 4001) {
+          //  Ignore reporting error if the user denies the request
+          return
+        } else {
+          this.actions.reportError(error)
+        }
       })
   }
 }


### PR DESCRIPTION
I'm not sure if this is the best way to handle this but I think we want to have the same behavior when rejecting network request changes as we do when rejecting signing requests where `isActive` will still evaluate to `true`. 