### PR TITLE
Frame integration: bump eth-provider

### DIFF
--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -27,6 +27,6 @@
     "@web3-react/types": "^8.0.12-beta.0"
   },
   "peerDependencies": {
-    "eth-provider": "^0.9.4"
+    "eth-provider": "^0.10.0"
   }
 }


### PR DESCRIPTION
In preparation for the new Frame release we're checking our integrations are up to date - will update this if I find any other issues but at the moment we could just do with a bump of `eth-provider`.