### PR TITLE
Fix useProvider

### DIFF
--- a/packages/example-next/components/Accounts.tsx
+++ b/packages/example-next/components/Accounts.tsx
@@ -14,9 +14,8 @@ function useBalances(
       let stale = false
 
       void Promise.all(accounts.map((account) => provider.getBalance(account))).then((balances) => {
-        if (!stale) {
-          setBalances(balances)
-        }
+        if (stale) return
+        setBalances(balances)
       })
 
       return () => {


### PR DESCRIPTION
- Forces a re-render after lazy-loading @ethersproject/providers. This was not done before because the re-render is only forced if state _changes_.
- Cancels state updates if the hook's component is unmounted (with a `stale` guard).
- Cleans up hooks tests to use idiomatic @testing-library/react (eg `result.current`, which auto-updates when the component is re-rendered due to state changes).