### PR TITLE
Use optional properties instead of `| undefined`

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,14 +83,14 @@ export abstract class Connector {
    * May also comply with EIP-3085 ({@link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3085.md}).
    * This property must be defined while the connector is active, unless a customProvider is provided.
    */
-  public provider: Provider | undefined
+  public provider?: Provider
 
   /**
    * An optional property meant to allow ethers providers to be used directly rather than via the experimental
    * 1193 bridge. If desired, this property must be defined while the connector is active, in which case it will
    * be preferred over provider.
    */
-  public customProvider: unknown | undefined
+  public customProvider?: unknown
 
   protected readonly actions: Actions
 


### PR DESCRIPTION
Currently having a `Connector`'s `customProvider` defined, results in a type error with `CoinbaseWallet`:

```
Type 'typeof CoinbaseWallet' is not assignable to type 'ConnectorCtor | [ConnectorCtor, Record<string, unknown>]'.
  Types of construct signatures are incompatible.
    Type 'new (actions: Actions, options: { url: string; }, connectEagerly?: boolean) => CoinbaseWallet' is not assignable to type 'new (actions: Actions, ...args: unknown[]) => Connector'.
      Property 'customProvider' is missing in type 'CoinbaseWallet' but required in type 'Connector'.
```

for context, this is what `ConnectorCtor` type is:

```ts
import type { Actions, Connector } from '@web3-react/types'

type ConnectorCtor = new (actions: Actions, ...args: unknown[]) => Connector
```

I noticed this error occuring only with `CoinbaseWallet`, because it doesn't have the `customProvider` field defined