### PR TITLE
fix: make sure the initialization to throw an exception when there is no match url

### DIFF
--- a/packages/network/src/index.spec.ts
+++ b/packages/network/src/index.spec.ts
@@ -23,6 +23,27 @@ describe('Network', () => {
   let connector: Network
   let mockConnector: MockJsonRpcProvider
 
+  describe('no url', () => {
+    beforeEach(() => {
+      let actions: Actions
+      ;[store, actions] = createWeb3ReactStoreAndActions()
+      connector = new Network({ actions, urlMap: {} })
+    })
+
+    describe('#activate', () => {
+      test('works', async () => {
+        let error = null
+        try {
+          await connector.activate()
+        } catch (err) {
+          error = err
+        }
+
+        expect(error).not.toBeNull()
+      })
+    })
+  })
+
   describe('single url', () => {
     beforeEach(() => {
       let actions: Actions

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -65,6 +65,8 @@ export class Network extends Connector {
 
     const urls = this.urlMap[chainId]
 
+    if (!urls) return Promise.reject('fail to initialize provider')
+
     // early return if we have a single jsonrpc provider already
     if (urls.length === 1 && !isUrl(urls[0])) {
       return (this.providerCache[chainId] = Promise.resolve(urls[0]))


### PR DESCRIPTION
A minor checking added to network initialization.

## Context
Found this when launching Uniswap interface locally and chose the Evmos chain. 
The original error I got is :
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/10917606/205565118-551ee30b-2261-4374-a08a-f09b0b833cd4.png">

So I looked into it a bit and seems we have a assumption that `urls` will not be empty which in fact it could be.

and 🤔  I reckon there is something we could do about it like : 
- Exit early when conditions check fails
- Make sure the user of web3-react can capture this Unhandled Rejection with a more meaningful error name.

Plz let me know if this makes sense to you :D 

## Changes
- Add additional `urls` null check.
- Add unit test for the edge case.
