### PR TITLE
Adding Rabby's open-sourced relay service after WalletConnect v1.0 relay servers' shutdown

### DIFF
--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -105,6 +105,7 @@ export class WalletConnect extends Connector {
 
     return (this.eagerConnection = import('@walletconnect/ethereum-provider').then(async (m) => {
       this.provider = new m.default({
+        bridge: 'https://derelay.rabby.io',
         ...this.options,
         chainId,
         rpc: await rpc,


### PR DESCRIPTION
## Issue

WalletConnect v1.0 relay server is expected to be offline on 28 June, 2023. To ensure uninterrupted usage and connectivity following the official v1.0 server shutdown, we are proposing the integration of [Rabby](https://github.com/RabbyHub/)'s open-sourced relay service. This relay service, maintained by Rabby, will guarantee continued connection between Dapps and Wallets using WalletConnect for users.

## Solution

We have included Rabby's self-host relay(https://derelay.rabby.io/) address in the web3 Wallet Connect kit, ensuring that users can connect to Dapp using WalletConnect. This address will become effective once the official relay server shuts down.

## Testing plan

We have thoroughly tested the solution in both the testing environment and the live online environment. Based on our testing, we are confident that the solution will enable users to connect to Dapps using WalletConnect without any issues.