### PR TITLE
fix: remove duplicated dep

### DIFF
--- a/packages/gnosis-safe/package.json
+++ b/packages/gnosis-safe/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@gnosis.pm/safe-apps-provider": "^0.12.0",
-    "@gnosis.pm/safe-apps-sdk": "^7.6.0",
     "@web3-react/types": "^8.0.20-beta.0"
   }
 }

--- a/packages/gnosis-safe/yarn.lock
+++ b/packages/gnosis-safe/yarn.lock
@@ -351,7 +351,7 @@
     "@gnosis.pm/safe-apps-sdk" "7.6.0"
     events "^3.3.0"
 
-"@gnosis.pm/safe-apps-sdk@7.6.0", "@gnosis.pm/safe-apps-sdk@^7.6.0":
+"@gnosis.pm/safe-apps-sdk@7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.6.0.tgz#fdd8fa57eb3d6be3ba384ee51cb5b2f5f6416fbc"
   integrity sha512-2MFdcNu/n2pioeX2TiXMmwtxvhl5SM8Y2RapDF8YxF11naubKvVXIg5KDJfmvGfXCn7wyqjLxkBcUkMPFbcS8w==
@@ -365,6 +365,13 @@
   integrity sha512-o/U2hN5RoK8sa6UT5hALc+4yveJ5qctMxCHe0VBJ5IE2KHqqwHrFteOVcrkunmgb5V5U8GfZVYhehuHDVN8WMA==
   dependencies:
     cross-fetch "^3.1.5"
+
+"@web3-react/types@^8.0.20-beta.0":
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-8.2.2.tgz#1ae7f11069d9a9c711aa4152f95331747fb1e551"
+  integrity sha512-PrPrJNjJhUX3lL/365llAZwY0bpUm9N52OjGMFyzCIX7IR13f7WLUk/LyQa9ALneCBu3cJUVTZANuFdqdREuvw==
+  dependencies:
+    zustand "4.4.0"
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -506,6 +513,11 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -523,3 +535,10 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+zustand@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.0.tgz#13b3e8ca959dd53d536034440aec382ff91b65c3"
+  integrity sha512-2dq6wq4dSxbiPTamGar0NlIG/av0wpyWZJGeQYtUOLegIUvhM2Bf86ekPlmgpUtS5uR7HyetSiktYrGsdsyZgQ==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
Hi,
While using the `@web3-react/gnosis` lib, I found that GnosisContext wasn't recognize.
But problem wasn't coming from my implementation as `"@gnosis.pm/safe-apps-sdk:7.8.0` package recognize perfectly the GnosisContext from my application.

So I investigate and i found where does the problem come from.
i don't know why but, GnosisSafe object is trying to load SDK object (from `@gnosis.pm/safe-apps-sdk` package) from a different path than the same package used by `@gnosis.pm/safe-apps-provider`.
So two versions of the same package was used in the repo.
I got a TypeScript error than indicate me where the error was come from.
