### PR TITLE
fix: example wc2 config

### DIFF
--- a/example/connectors/walletConnectV2.ts
+++ b/example/connectors/walletConnectV2.ts
@@ -3,7 +3,8 @@ import { WalletConnect as WalletConnectV2 } from '@web3-react/walletconnect-v2'
 
 import { MAINNET_CHAINS } from '../chains'
 
-const [mainnet, ...optionalChains] = Object.keys(MAINNET_CHAINS).map(Number)
+const optionalChains = Object.keys(MAINNET_CHAINS).map(Number)
+const [mainnet] = optionalChains
 
 export const [walletConnectV2, hooks] = initializeConnector<WalletConnectV2>(
   (actions) =>


### PR DESCRIPTION
fix: Invalid chainId 1. Make sure default chain is included in "chains" - chains specified in "optionalChains" may not be selected as the default, as they may not be supported by the wallet.

<img width="381" alt="image" src="https://github.com/Uniswap/web3-react/assets/48060080/9f13ef27-76d9-4640-9e6e-7e8a0e3137af">
